### PR TITLE
Fix output path not working for production builds

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -43,3 +43,4 @@ __tests__
 **/copyStylelintConfig.js
 **/content.tsx
 **/content.tsx
+programs/create/templates/**

--- a/packages/manifest-compat-plugin/handleRuntimeErrors/handleFirefoxRunningServiceWorkerError.ts
+++ b/packages/manifest-compat-plugin/handleRuntimeErrors/handleFirefoxRunningServiceWorkerError.ts
@@ -9,7 +9,7 @@ export default function handleFirefoxRunningServiceWorkerError(
   if (browser === 'firefox') {
     if (manifest.background.service_worker) {
       return new webpack.WebpackError(
-        `${bgWhite(red(bold(` firefox-browser `)))} ${yellow(`►►►`)} ` +
+        `${bgWhite(red(bold(` firefox-browser `)))} ${red(`►►►`)} ` +
           `Firefox does not support the ${yellow('background.service_worker')} field yet.\n` +
           `See ${blue(underline('https://bugzilla.mozilla.org/show_bug.cgi?id=1573659'))}.\n\n` +
           `Update your ${yellow('manifest.json')} file to use ${yellow('background.scripts')} instead.`

--- a/packages/run-chrome-extension/helpers/messages.ts
+++ b/packages/run-chrome-extension/helpers/messages.ts
@@ -13,8 +13,6 @@ import {
   magenta,
   cyan
 } from '@colors/colors/safe'
-// @ts-ignore
-import prefersYarn from 'prefers-yarn'
 import getDirectorySize from '../steps/calculateDirSize'
 import {type ManifestBase} from '../manifest-types'
 

--- a/packages/run-chrome-extension/steps/RunChromePlugin/chrome/browser.config.ts
+++ b/packages/run-chrome-extension/steps/RunChromePlugin/chrome/browser.config.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import {Compiler} from 'webpack'
+import {type Compiler} from 'webpack'
 import {type RunChromeExtensionInterface} from '../../../types'
 import createUserDataDir from './createUserDataDir'
 

--- a/packages/run-firefox-addon/helpers/messages.ts
+++ b/packages/run-firefox-addon/helpers/messages.ts
@@ -44,7 +44,7 @@ one of the options above, and try again.
 `)
 }
 
-function extensionData(compiler: Compiler, message: {data?: Data}) {
+function extensionData(projectPath: string, message: {data?: Data}) {
   if (!message.data) {
     // TODO: cezaraugusto this happens when the extension
     // can't reach the background script. This can be many
@@ -59,7 +59,6 @@ Ensure your extension is enabled and that no hanging Firefox instance is open th
     process.exit(1)
   }
 
-  const compilerOptions = compiler.options
   const {id, management} = message.data
 
   if (!management) {
@@ -74,8 +73,8 @@ Ensure your extension is enabled and that no hanging Firefox instance is open th
 
   const {name, description, version, hostPermissions, permissions} = management
 
-  const manifestPath = path.join(compilerOptions.context || '', 'manifest.json')
-  const manifestFromCompiler = require(manifestPath)
+  const outputPath = path.join(projectPath, 'dist', 'firefox')
+  const manifestFromCompiler = require(path.join(outputPath, 'manifest.json'))
   const hostPermissionsParsed = hostPermissions?.filter(
     (permission) => !permission.startsWith('moz-extension://')
   )
@@ -94,11 +93,8 @@ Ensure your extension is enabled and that no hanging Firefox instance is open th
   log(`${bold(`• Name:`)} ${name}`)
   description && log(`${bold(`• Description:`)} ${description}`)
   log(`${bold(`• Version:`)} ${version}`)
-  log(
-    `${bold(`• Size:`)} ${getDirectorySize(
-      compilerOptions.output.path || 'dist'
-    )}`
-  )
+  log(`${bold(`• Size:`)} ${getDirectorySize(outputPath)}`)
+  // log(`${bold(`• Size:`)} ${getDirectorySize(projectPath)}`)
   log(`${bold(`• ID:`)} ${id} (${fixedId ? 'permantent' : 'temporary'})`)
   hasHost &&
     log(

--- a/packages/run-firefox-addon/helpers/messages.ts
+++ b/packages/run-firefox-addon/helpers/messages.ts
@@ -94,7 +94,6 @@ Ensure your extension is enabled and that no hanging Firefox instance is open th
   description && log(`${bold(`• Description:`)} ${description}`)
   log(`${bold(`• Version:`)} ${version}`)
   log(`${bold(`• Size:`)} ${getDirectorySize(outputPath)}`)
-  // log(`${bold(`• Size:`)} ${getDirectorySize(projectPath)}`)
   log(`${bold(`• ID:`)} ${id} (${fixedId ? 'permantent' : 'temporary'})`)
   hasHost &&
     log(

--- a/packages/scripts-plugin/loaders/InjectDynamicPublicPathLoader.ts
+++ b/packages/scripts-plugin/loaders/InjectDynamicPublicPathLoader.ts
@@ -1,0 +1,63 @@
+import path from 'path'
+import {urlToRequest} from 'loader-utils'
+import {validate} from 'schema-utils'
+import {type LoaderContext} from 'webpack'
+import {type Schema} from 'schema-utils/declarations/validate'
+import {isUsingReact} from '../helpers/utils'
+
+const schema: Schema = {
+  type: 'object',
+  properties: {
+    test: {
+      type: 'string'
+    },
+    manifestPath: {
+      type: 'string'
+    }
+  }
+}
+
+interface InjectDynamicPublicPathLoaderContext extends LoaderContext<any> {
+  getOptions: () => {
+    manifestPath: string
+  }
+}
+
+export default function (this: InjectDynamicPublicPathLoaderContext, source: string) {
+  const options = this.getOptions()
+  const manifestPath = options.manifestPath
+  const projectPath = path.dirname(manifestPath)
+  const manifest = require(manifestPath)
+
+  validate(schema, options, {
+    name: 'Inject the dynamic webpack publicPath code',
+    baseDataPath: 'options'
+  })
+
+  if (this._compilation?.options.mode === 'production') return source
+
+  const url = urlToRequest(this.resourcePath)
+  const reloadCode = `
+;__webpack_public_path__ = chrome.extension.getURL('/');
+  `
+
+  if (manifest.background) {
+    if (manifest.background.scripts) {
+      for (const bgScript of manifest.background.scripts) {
+        const absoluteUrl = path.resolve(projectPath, bgScript as string)
+        if (url.includes(absoluteUrl)) {
+          return `${reloadCode}${source}`
+        }
+      }
+    }
+
+    if (manifest.background.service_worker) {
+      const absoluteUrl = path.resolve(projectPath, manifest.background.service_worker)
+      if (url.includes(absoluteUrl)) {
+        return `${reloadCode}${source}`
+      }
+    }
+  }
+
+  return source
+}

--- a/packages/scripts-plugin/module.ts
+++ b/packages/scripts-plugin/module.ts
@@ -5,6 +5,7 @@ import {type IncludeList, type ScriptsPluginInterface} from './types'
 import AddScripts from './steps/AddScripts'
 import AddStyles from './steps/AddStyles'
 import AddHmrAcceptCode from './steps/AddHmrAcceptCode'
+import AddPublicPathRuntimeModule from './steps/AddPublicPathRuntimeModule'
 
 /**
  * ScriptsPlugin is responsible for handiling all possible JavaScript
@@ -71,5 +72,13 @@ export default class ScriptsPlugin {
 
     // 2 - Ensure scripts are HMR enabled by adding the HMR accept code.
     AddHmrAcceptCode(compiler, this.manifestPath)
+
+    // Fix the issue with the public path not being
+    // available for content_scripts in the production build.
+    // See https://github.com/cezaraugusto/extension.js/issues/95
+    // See https://github.com/cezaraugusto/extension.js/issues/96
+    if (compiler.options.mode === 'production') {
+      new AddPublicPathRuntimeModule().apply(compiler)
+    }
   }
 }

--- a/packages/scripts-plugin/module.ts
+++ b/packages/scripts-plugin/module.ts
@@ -6,6 +6,7 @@ import AddScripts from './steps/AddScripts'
 import AddStyles from './steps/AddStyles'
 import AddHmrAcceptCode from './steps/AddHmrAcceptCode'
 import AddPublicPathRuntimeModule from './steps/AddPublicPathRuntimeModule'
+import AddDynamicPublicPath from './steps/AddDynamicPublicPath'
 
 /**
  * ScriptsPlugin is responsible for handiling all possible JavaScript
@@ -80,5 +81,9 @@ export default class ScriptsPlugin {
     if (compiler.options.mode === 'production') {
       new AddPublicPathRuntimeModule().apply(compiler)
     }
+
+    // Fix the issue where assets imported via content_scripts
+    // running in the MAIN world could not find the correct public path.
+    AddDynamicPublicPath(compiler, this.manifestPath)
   }
 }

--- a/packages/scripts-plugin/steps/AddDynamicPublicPath.ts
+++ b/packages/scripts-plugin/steps/AddDynamicPublicPath.ts
@@ -1,10 +1,7 @@
 import path from 'path'
 import {type Compiler} from 'webpack'
 
-export default function AddHmrAcceptCode(
-  compiler: Compiler,
-  manifestPath: string
-) {
+export default function AddDynamicPublicPath(compiler: Compiler, manifestPath: string) {
   compiler.options.module.rules.push({
     test: /\.(m?js|m?ts)x?$/,
     use: [

--- a/packages/scripts-plugin/steps/AddPublicPathRuntimeModule.ts
+++ b/packages/scripts-plugin/steps/AddPublicPathRuntimeModule.ts
@@ -1,0 +1,57 @@
+// This source file is adapted from
+// https://github.com/awesome-webextension/webpack-target-webextension
+// Released under the MIT License.
+
+import {RuntimeGlobals, RuntimeModule, Template, type Compiler} from 'webpack'
+
+const basic = [
+  `var isBrowser = !!(() => { try { return browser.runtime.getURL("/") } catch(e) {} })()`,
+  `var isChrome = !!(() => { try { return chrome.runtime.getURL("/") } catch(e) {} })()`
+]
+
+const weakRuntimeCheck = [
+  ...basic,
+  `var runtime = isBrowser ? browser : isChrome ? chrome : (typeof self === 'object' && self.addEventListener) ? { get runtime() { throw new Error("No chrome or browser runtime found") } } : { runtime: { getURL: x => x } }`
+]
+
+export default class AddPublicPathRuntimeModule {
+  apply(compiler: Compiler) {
+    const {RuntimeGlobals} = compiler.webpack
+
+    compiler.hooks.compilation.tap('PublicPathRuntimeModule', (compilation) => {
+      compilation.hooks.runtimeRequirementInTree
+        .for(RuntimeGlobals.publicPath)
+        .tap(AddPublicPathRuntimeModule.name, (chunk) => {
+          const module = PublicPathRuntimeModule()
+
+          compilation.addRuntimeModule(chunk, module)
+
+          return true
+        })
+    })
+  }
+}
+
+function PublicPathRuntimeModule() {
+  class PublicPathRuntimeModule extends RuntimeModule {
+    constructor() {
+      super('publicPath', RuntimeModule.STAGE_BASIC)
+    }
+
+    generate() {
+      const publicPath = this.compilation?.outputOptions.publicPath
+
+      return Template.asString([
+        ...weakRuntimeCheck,
+        `var path = ${JSON.stringify(
+          this.compilation?.getPath(publicPath || '', {
+            hash: this.compilation.hash || 'XXXX'
+          })
+        )}`,
+        `${RuntimeGlobals.publicPath} = typeof importScripts === 'function' || !(isBrowser || isChrome) ? path : runtime.runtime.getURL(path);`
+      ])
+    }
+  }
+
+  return new PublicPathRuntimeModule()
+}

--- a/packages/scripts-plugin/steps/AddQueryParamFromImportedCss.ts
+++ b/packages/scripts-plugin/steps/AddQueryParamFromImportedCss.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import {type Compiler} from 'webpack'
 
-export default function AddDynamicPublicPath(
+export default function RemoveQueryParamFromImportedCss(
   compiler: Compiler,
   manifestPath: string
 ) {
@@ -9,7 +9,7 @@ export default function AddDynamicPublicPath(
     test: /\.(m?js|m?ts)x?$/,
     use: [
       {
-        loader: path.resolve(__dirname, './loaders/InjectHMRAcceptLoader'),
+        loader: path.resolve(__dirname, './loaders/InjectQueryParamLoader'),
         options: {
           manifestPath
         }

--- a/programs/create/templates/content/template/content.js
+++ b/programs/create/templates/content/template/content.js
@@ -1,5 +1,5 @@
 import extensionJsLogo from './images/extensionjs.svg'
-import('./content.css')
+import './content.css'
 
 document.body.innerHTML += `
 <div class="content_script-box">

--- a/programs/create/templates/preact-typescript/template/content/content.tsx
+++ b/programs/create/templates/preact-typescript/template/content/content.tsx
@@ -1,7 +1,7 @@
 import {render} from 'preact'
 import ContentApp from './ContentApp'
-import('./base.css')
-import('./content.css')
+import './base.css'
+import './content.css'
 
 setTimeout(initial, 1000)
 

--- a/programs/create/templates/react-typescript/template/content/content.tsx
+++ b/programs/create/templates/react-typescript/template/content/content.tsx
@@ -1,8 +1,7 @@
-import React from 'react'
 import ReactDOM from 'react-dom/client'
 import ContentApp from './ContentApp'
-import('./base.css')
-import('./content.css')
+import './base.css'
+import './content.css'
 
 setTimeout(initial, 1000)
 

--- a/programs/create/templates/vue-typescript/template/content/content.ts
+++ b/programs/create/templates/vue-typescript/template/content/content.ts
@@ -1,5 +1,5 @@
-import('./base.css')
-import('./content.css')
+import './base.css'
+import './content.css'
 import {createApp} from 'vue'
 import ContentApp from './ContentApp.vue'
 

--- a/programs/create/templates/vue-typescript/template/content/content.ts
+++ b/programs/create/templates/vue-typescript/template/content/content.ts
@@ -1,6 +1,5 @@
-import './base.css'
-import './content.css'
-// @ts-ignore
+import('./base.css')
+import('./content.css')
 import {createApp} from 'vue'
 import ContentApp from './ContentApp.vue'
 

--- a/programs/develop/extensionStart.ts
+++ b/programs/develop/extensionStart.ts
@@ -43,9 +43,10 @@ export default async function extensionStart(
         console.error(err.stack || err)
         process.exit(1)
       }
-      messages.startWebpack(projectPath, startOptions)
 
       if (!stats?.hasErrors()) {
+        messages.startWebpack(projectPath, startOptions)
+
         setTimeout(() => {
           messages.ready(startOptions)
         }, 1500)

--- a/programs/develop/messages/startMessage.ts
+++ b/programs/develop/messages/startMessage.ts
@@ -34,7 +34,6 @@ export function startWebpack(projectDir: string, options: StartOptions) {
 
   const {name, description, version, hostPermissions, permissions} = manifest
 
-  const manifestFromCompiler = require(manifestPath)
   const defaultLocale = getLocales(projectDir, manifest).defaultLocale
   const otherLocales = getLocales(projectDir, manifest).otherLocales.join(', ')
   const locales = `${defaultLocale} (default) ${otherLocales && ', ' + otherLocales}`

--- a/programs/develop/webpack/loaders/commonStyleLoaders.ts
+++ b/programs/develop/webpack/loaders/commonStyleLoaders.ts
@@ -15,7 +15,7 @@ export default function getCommonStyleLoaders(
   opts: any
 ): any {
   const styleLoaders: webpack.RuleSetUse = [
-    opts.mode === 'production'
+    opts.useMiniCssExtractPlugin
       ? MiniCssExtractPlugin.loader
       : require.resolve('style-loader'),
     require.resolve('css-loader'),
@@ -31,7 +31,6 @@ export default function getCommonStyleLoaders(
             ...(isUsingTailwind(projectDir)
               ? [require.resolve('tailwindcss', {paths: [projectDir]})]
               : []),
-
             require.resolve('postcss-flexbugs-fixes'),
             [
               require.resolve('postcss-preset-env'),

--- a/programs/develop/webpack/loaders/styleLoaders.ts
+++ b/programs/develop/webpack/loaders/styleLoaders.ts
@@ -7,10 +7,23 @@ export default function styleLoaders(projectDir: string, opts: any) {
       exclude: /\.module\.css$/,
       type: 'javascript/auto',
       // https://stackoverflow.com/a/60482491/4902448
-      use: getCommonStyleLoaders(projectDir, {
-        regex: /\.css$/,
-        mode: opts.mode
-      })
+      oneOf: [
+        {
+          resourceQuery: /is_content_css_import=true/,
+          use: getCommonStyleLoaders(projectDir, {
+            regex: /\.css$/,
+            mode: opts.mode,
+            useMiniCssExtractPlugin: false
+          })
+        },
+        {
+          use: getCommonStyleLoaders(projectDir, {
+            regex: /\.css$/,
+            mode: opts.mode,
+            useMiniCssExtractPlugin: true
+          })
+        }
+      ]
     },
     {
       test: /\.module\.css$/,
@@ -18,38 +31,67 @@ export default function styleLoaders(projectDir: string, opts: any) {
       // https://stackoverflow.com/a/60482491/4902448
       use: getCommonStyleLoaders(projectDir, {
         regex: /\.module\.css$/,
-        mode: opts.mode
+        mode: opts.mode,
+        useMiniCssExtractPlugin: true
       })
     },
     {
       test: /\.(scss|sass)$/,
       exclude: /\.module\.css$/,
       // https://stackoverflow.com/a/60482491/4902448
-      use: getCommonStyleLoaders(projectDir, {
-        regex: /\.module\.css$/,
-        loader: require.resolve('sass-loader'),
-        mode: opts.mode
-      })
+      oneOf: [
+        {
+          resourceQuery: /is_content_css_import=true/,
+          use: getCommonStyleLoaders(projectDir, {
+            regex: /\.(scss|sass)$/,
+            loader: require.resolve('sass-loader'),
+            mode: opts.mode,
+            useMiniCssExtractPlugin: false
+          })
+        },
+        {
+          use: getCommonStyleLoaders(projectDir, {
+            regex: /\.(scss|sass)$/,
+            loader: require.resolve('sass-loader'),
+            mode: opts.mode,
+            useMiniCssExtractPlugin: true
+          })
+        }
+      ]
     },
     {
       test: /\.module\.(scss|sass)$/,
-      exclude: /\.module\.css$/,
       // https://stackoverflow.com/a/60482491/4902448
       use: getCommonStyleLoaders(projectDir, {
-        regex: /\.module\.css$/,
+        regex: /\.module\.(scss|sass)$/,
         loader: require.resolve('sass-loader'),
-        mode: opts.mode
+        mode: opts.mode,
+        useMiniCssExtractPlugin: true
       })
     },
     {
       test: /\.less$/,
       exclude: /\.module\.css$/,
       // https://stackoverflow.com/a/60482491/4902448
-      use: getCommonStyleLoaders(projectDir, {
-        regex: /\.module\.css$/,
-        loader: require.resolve('less-loader'),
-        mode: opts.mode
-      })
+      oneOf: [
+        {
+          resourceQuery: /is_content_css_import=true/,
+          use: getCommonStyleLoaders(projectDir, {
+            regex: /\.less$/,
+            loader: require.resolve('less-loader'),
+            mode: opts.mode,
+            useMiniCssExtractPlugin: false
+          })
+        },
+        {
+          use: getCommonStyleLoaders(projectDir, {
+            regex: /\.less$/,
+            loader: require.resolve('less-loader'),
+            mode: opts.mode,
+            useMiniCssExtractPlugin: true
+          })
+        }
+      ]
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "**/dist",
     "node_modules",
     "browser-extension-test-data",
-    "__TEST__"
+    "__TEST__",
+    "programs/create/templates/**"
   ]
 }


### PR DESCRIPTION
I made some changes to the `main` branch and now the `start` command is now a combination of the `build` + `preview` commands, so running `yarn start <extension-path>` should reflect the extension in a production environment.

To test this PR, ensure that:

1. Running `yarn start <extension-path>` for the React template builds the extension and loads the browser in production.
2. Running `yarn start <extension-path>` for the Vue.js template builds the extension and loads the browser in production. 
3. Good to test the templates in different browsers such as `--browser=edge` or `--browser=firefox --polyfill`
  - **Side note**: if testing Firefox, ensure `manifest_version` is set to `2` and uses `background.scripts` instead of `background.service_worker`. For some reason I couldn't make it work using V3.
5. The `background.service_worker` caches while switching between between `dev`/`start` commands, so good to test toggling between these environments to assert the extension reloads as usual.
6. Ensure that during development hard-reloading (like <kbd>cmd</kbd>+<kbd>r</kbd>) a page with a content script does not prevent future HMR reloads (i.e. reloading a content_scripts extension after a manual page reload should work just fine).

Tough one!

## React-TypeScript template (production mode)
<img width="1644" alt="Screenshot 2024-06-18 at 13 55 39" src="https://github.com/cezaraugusto/extension.js/assets/4672033/6d26e606-1bf3-4315-8a14-dd6b04a856f2">


## Vue-TypeScript template (production mode)
<img width="1645" alt="Screenshot 2024-06-18 at 16 40 28" src="https://github.com/cezaraugusto/extension.js/assets/4672033/9ecd11c4-741a-46ea-b2e9-8aa5cc325211">

Fix #95
Fix #96

