### PR TITLE
Make icons-path style same

### DIFF
--- a/packages/manifest-plugin/__tests__/__utils__.ts
+++ b/packages/manifest-plugin/__tests__/__utils__.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import fs from 'fs-extra'
+import os from 'os'
 
 export const getFixturesPath = (demoDir: string) =>
   path.join(__dirname, 'fixtures', demoDir, 'manifest.json')
@@ -19,3 +20,7 @@ export const findStringInFile = async (filePath: string, string: string) => {
     expect(data).toContain(string)
   })
 }
+
+export const dirname = (dir: string) => path.dirname(dir)
+
+export const win32 = () => os.platform() === 'win32'

--- a/packages/manifest-plugin/__tests__/manifest-overrides/index.spec.ts
+++ b/packages/manifest-plugin/__tests__/manifest-overrides/index.spec.ts
@@ -1,9 +1,16 @@
 import manifestOverries from '../../manifest-overrides'
-import {getFixturesPath} from '../__utils__'
+import {dirname, getFixturesPath, win32} from '../__utils__'
 
 describe('manifestOverries', () => {
   const manifestPath = getFixturesPath('super-manifest')
-  const exclude = ['/public/some/file']
+  const context = dirname(manifestPath)
+  const exclude = win32()
+    ? [
+        `${context}\\icons\\icon16.png`,
+        `${context}\\icons\\icon48.png`,
+        `${context}\\icons\\icon128.png`
+      ]
+    : ['icons/icon16.png', 'icons/icon48.png', 'icons/icon128.png']
 
   it('should transform manifest action details correctly', () => {
     const result = manifestOverries(manifestPath, undefined, exclude)
@@ -19,7 +26,7 @@ describe('manifestOverries', () => {
         service_worker: 'background/service_worker.js'
       },
       browser_action: {
-        default_icon: 'browser_action/icon16.png',
+        default_icon: 'icons/icon16.png',
         default_popup: 'browser_action/default_popup.html',
         theme_icons: [
           {
@@ -77,7 +84,7 @@ describe('manifestOverries', () => {
         page: 'options_ui/page.html'
       },
       page_action: {
-        default_icon: 'page_action/icon16.png',
+        default_icon: 'icons/icon16.png',
         default_popup: 'page_action/default_popup.html'
       },
       sandbox: {
@@ -85,7 +92,7 @@ describe('manifestOverries', () => {
       },
       sidebar_action: {
         default_panel: 'sidebar_action/default_panel.html',
-        default_icon: 'sidebar_action/icon16.png'
+        default_icon: 'icons/icon16.png'
       },
       storage: {
         managed_schema: 'storage/managed_schema.json'

--- a/packages/manifest-plugin/helpers/getFilename.ts
+++ b/packages/manifest-plugin/helpers/getFilename.ts
@@ -11,19 +11,19 @@ export default function getFilename(
   // Do not attempt to rewrite the asset path if it's in the exclude list.
   const shouldSkipRewrite = utils.shouldExclude(filepath, exclude)
 
-  const fileOutputpath = shouldSkipRewrite ? path.normalize(filepath) : feature
+  let fileOutputpath = shouldSkipRewrite ? path.normalize(filepath) : feature
 
   if (['.js', '.jsx', '.tsx', '.ts'].includes(entryExt)) {
-    return fileOutputpath.replace(entryExt, '.js')
+    fileOutputpath = fileOutputpath.replace(entryExt, '.js')
   }
 
   if (['.html', '.njk', '.nunjucks'].includes(entryExt)) {
-    return fileOutputpath.replace(entryExt, '.html')
+    fileOutputpath = fileOutputpath.replace(entryExt, '.html')
   }
 
   if (['.css', '.scss', '.sass', '.less'].includes(entryExt)) {
-    return fileOutputpath.replace(entryExt, '.css')
+    fileOutputpath = fileOutputpath.replace(entryExt, '.css')
   }
 
-  return fileOutputpath
+  return utils.unixify(fileOutputpath)
 }

--- a/packages/manifest-plugin/helpers/utils.ts
+++ b/packages/manifest-plugin/helpers/utils.ts
@@ -5,13 +5,15 @@ import {type Manifest} from '../types'
  * Change the path from win style to unix style
  */
 function unixify(path: string) {
-  return path.replace(/\\/g, '/');
+  return path.replace(/\\/g, '/')
 }
 
 function shouldExclude(path: string, ignorePatterns: string[]): boolean {
   return ignorePatterns.some((pattern) => {
     const _pattern = unixify(pattern)
-    return path.includes(_pattern.startsWith('/') ? _pattern.slice(1) : _pattern)
+    return path.includes(
+      _pattern.startsWith('/') ? _pattern.slice(1) : _pattern
+    )
   })
 }
 

--- a/packages/manifest-plugin/helpers/utils.ts
+++ b/packages/manifest-plugin/helpers/utils.ts
@@ -1,9 +1,17 @@
 import {type Compilation} from 'webpack'
 import {type Manifest} from '../types'
 
+/**
+ * Change the path from win style to unix style
+ */
+function unixify(path: string) {
+  return path.replace(/\\/g, '/');
+}
+
 function shouldExclude(path: string, ignorePatterns: string[]): boolean {
   return ignorePatterns.some((pattern) => {
-    return path.includes(pattern)
+    const _pattern = unixify(pattern)
+    return path.includes(_pattern.startsWith('/') ? _pattern.slice(1) : _pattern)
   })
 }
 
@@ -23,6 +31,7 @@ function getManifestContent(
 }
 
 export default {
+  unixify,
   shouldExclude,
   getManifestContent
 }

--- a/packages/manifest-plugin/manifest-overrides/common/icons.ts
+++ b/packages/manifest-plugin/manifest-overrides/common/icons.ts
@@ -1,7 +1,6 @@
 import path from 'path'
 import {type Manifest} from '../../types'
 import getFilename from '../../helpers/getFilename'
-import utils from '../../helpers/utils'
 
 const getBasename = (filepath: string) => path.basename(filepath)
 
@@ -10,10 +9,9 @@ export default function icons(manifest: Manifest, exclude: string[]) {
     manifest.icons && {
       icons: Object.fromEntries(
         Object.entries(manifest.icons).map(([size, icon]) => {
-          const outputpath = utils.unixify(getFilename(`icons/${getBasename(icon)}`, icon, exclude));
           return [
             size,
-            outputpath
+            getFilename(`icons/${getBasename(icon)}`, icon, exclude)
           ]
         })
       )

--- a/packages/manifest-plugin/manifest-overrides/common/icons.ts
+++ b/packages/manifest-plugin/manifest-overrides/common/icons.ts
@@ -1,6 +1,7 @@
 import path from 'path'
 import {type Manifest} from '../../types'
 import getFilename from '../../helpers/getFilename'
+import utils from '../../helpers/utils'
 
 const getBasename = (filepath: string) => path.basename(filepath)
 
@@ -9,9 +10,10 @@ export default function icons(manifest: Manifest, exclude: string[]) {
     manifest.icons && {
       icons: Object.fromEntries(
         Object.entries(manifest.icons).map(([size, icon]) => {
+          const outputpath = utils.unixify(getFilename(`icons/${getBasename(icon)}`, icon, exclude));
           return [
             size,
-            getFilename(`icons/${getBasename(icon)}`, icon, exclude)
+            outputpath
           ]
         })
       )


### PR DESCRIPTION
hi~ @cezaraugusto 

Regarding the inconsistency in the `icons` path output, I made some modifications:

1. In `shouldExclude()`, I converted the `pattern` to Unix path style to ensure the files that need to be excluded are correctly excluded.
2. Since `manifest.json` cannot use Windows path style, I also applied `unixify()` to the output of `icons()`.

I need your verification on these changes ~