### PR TITLE
Fixed import component name

### DIFF
--- a/programs/create/templates/react/template/newtab/scripts.jsx
+++ b/programs/create/templates/react/template/newtab/scripts.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import NewtabApp from './NewtabApp'
+import NewtabApp from './NewTabApp'
 import './styles.css'
 
 const root = ReactDOM.createRoot(document.getElementById('root'))


### PR DESCRIPTION
I modified the component name import because I encountered the following error message when running `yarn dev`:

![image](https://github.com/extension-js/extension.js/assets/10126623/cb2143f4-63b6-4e0e-bca9-f3e0900ebd85)
