### PR TITLE
Remove invalid args

### DIFF
--- a/packages/run-chrome-extension/steps/RunChromePlugin/index.ts
+++ b/packages/run-chrome-extension/steps/RunChromePlugin/index.ts
@@ -51,7 +51,9 @@ export default class ChromeExtensionLauncherPlugin {
     }
 
     const chromeConfig = browserConfig(compiler, this.options)
-    const launchArgs = [this.options.startingUrl || '', ...chromeConfig]
+    const launchArgs = this.options.startingUrl
+      ? [this.options.startingUrl, ...chromeConfig]
+      : [...chromeConfig]
 
     const stdio =
       process.env.EXTENSION_ENV === 'development' ? 'inherit' : 'ignore'

--- a/packages/run-edge-extension/steps/RunEdgePlugin/index.ts
+++ b/packages/run-edge-extension/steps/RunEdgePlugin/index.ts
@@ -46,7 +46,9 @@ export default class EdgeExtensionLauncherPlugin {
     }
 
     const edgeConfig = browserConfig(compiler, this.options)
-    const launchArgs = [this.options.startingUrl || '', ...edgeConfig]
+    const launchArgs = this.options.startingUrl
+      ? [this.options.startingUrl, ...edgeConfig]
+      : [...edgeConfig]
 
     const stdio =
       process.env.EXTENSION_ENV === 'development' ? 'inherit' : 'ignore'


### PR DESCRIPTION
When the `startingUrl` option is not passed in, `launchArgs` will include an empty string as the first argument in the array, but this results in an unexpected phenomenon in the win environment.

![2551719549780_ pic](https://github.com/extension-js/extension.js/assets/10126623/1d69bb12-e67e-44b3-8dc0-129bad09872f)
