### PR TITLE
Fix chrome.windows.create API not working

### DIFF
--- a/packages/resolve-plugin/__tests__/steps/transformSource/transformSource.spec.ts
+++ b/packages/resolve-plugin/__tests__/steps/transformSource/transformSource.spec.ts
@@ -65,4 +65,26 @@ describe('transformSource Tests', () => {
     expect(firstArg.type).toBe('CallExpression')
     expect(firstArg.callee.name).toBe('r.solve')
   })
+
+  // https://developer.chrome.com/docs/extensions/reference/api/windows#property-create-createData-url
+  test('should transform chrome.windows.create when URL argument is an array', () => {
+    const code = `chrome.windows.create({url: ['https://www.extension.js.org/']})`
+    const ast = parse(code)
+    transformSource(ast, code)
+    // Check if the first argument of the first expression is a call to resolveString
+    const firstArg = (ast.program.body[0] as any).expression.arguments[0]
+    expect(firstArg.type).toBe('CallExpression')
+    expect(firstArg.callee.name).toBe('r.solve')
+  })
+
+  test('should transform chrome.windows.create when URL argument is a string', () => {
+    const code = `chrome.windows.create({url: 'https://www.extension.js.org/'})`
+    const ast = parse(code)
+    transformSource(ast, code)
+    // Check if the first argument of the first expression is a call to resolveString
+    const firstArg = (ast.program.body[0] as any).expression.arguments[0]
+    expect(firstArg.type).toBe('CallExpression')
+    expect(firstArg.callee.name).toBe('r.solve')
+  })
 })
+

--- a/packages/resolve-plugin/resolver-module.ts
+++ b/packages/resolve-plugin/resolver-module.ts
@@ -153,8 +153,12 @@ function solve(apiArgument?: SolveType) {
     // chrome.tabs.create({..., url: string})
     // chrome.tabs.executeScript({..., url: string})
     // chrome.tabs.insertCSS({..., url: string})
-    // chrome.windows.create({..., url: string})
-    ...(obj?.url && {url: resolver(obj.url)}),
+    // chrome.windows.create({..., url: string || string[]})
+    ...(obj?.url && {
+      url: Array.isArray(obj?.url)
+        ? obj?.url.map((currentUrl: string) => resolver(currentUrl))
+        : resolver(obj?.url)
+    }),
 
     // chrome.notifications.create
     // https://developer.chrome.com/docs/extensions/reference/api/notifications#property-NotificationOptions-iconUrl


### PR DESCRIPTION
The resolver plugin didn't catch this case which raised a bug


Address #112 