### PR TITLE
Fix styles not working during development

### DIFF
--- a/programs/develop/webpack/loaders/styleLoaders.ts
+++ b/programs/develop/webpack/loaders/styleLoaders.ts
@@ -20,7 +20,7 @@ export default function styleLoaders(projectDir: string, opts: any) {
           use: getCommonStyleLoaders(projectDir, {
             regex: /\.css$/,
             mode: opts.mode,
-            useMiniCssExtractPlugin: true
+            useMiniCssExtractPlugin: opts.mode === 'production'
           })
         }
       ]


### PR DESCRIPTION
This was a regression during a fix for styles in content_scripts. 

The error happened because the Html Plugin does not emit a <link> tag during development as it uses style-loader to inject styles in the <style> tag. Using `useMiniCssExtractPlugin` means we do not use the style-loader so the styles are emitted in a separate file instead of the style injection, but the Html Plugin won't see it during development.

Fix #105 