### PR TITLE
Build the zip artifact in dist/ instead of dist/[browser]

### DIFF
--- a/programs/cli/spec/build.spec.ts
+++ b/programs/cli/spec/build.spec.ts
@@ -20,7 +20,7 @@ describe('extension build', () => {
   })
 
   describe('running built-in templates', () => {
-    it.skip.each(ALL_TEMPLATES)(
+    it.each(ALL_TEMPLATES)(
       `builds an extension created via "$name" template`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -47,7 +47,7 @@ describe('extension build', () => {
   })
 
   describe('using the --browser flag', () => {
-    it.skip.each(ALL_TEMPLATES)(
+    it.each(ALL_TEMPLATES)(
       `builds the "$name" extension template across all browsers`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -78,7 +78,7 @@ describe('extension build', () => {
   })
 
   describe('using the --zip flag', () => {
-    it.skip.each([DEFAULT_TEMPLATE])(
+    it.each([DEFAULT_TEMPLATE])(
       `builds and zips the distribution files of an extension created via "$name" template`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -94,7 +94,12 @@ describe('extension build', () => {
       `builds and zips the source files of an extension created via "$name" template`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
-        const outputPath = path.join(__dirname, 'fixtures', template.name, 'dist')
+        const outputPath = path.join(
+          __dirname,
+          'fixtures',
+          template.name,
+          'dist'
+        )
 
         await extensionProgram(`build ${extensionPath} --zip-source`)
 
@@ -107,7 +112,7 @@ describe('extension build', () => {
       50000
     )
 
-    it.skip.each([DEFAULT_TEMPLATE])(
+    it.each([DEFAULT_TEMPLATE])(
       `builds and zips the distribution files of an extension created via "$name" template with a custom output name using the --zip-filename flag`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -117,7 +122,7 @@ describe('extension build', () => {
         )
 
         expect(
-          distFileExists(template.name, `${template.name}-nice.zip`)
+          distFileExists(template.name, BROWSERS[0], `${template.name}-nice.zip`)
         ).toBeTruthy()
       },
       50000

--- a/programs/cli/spec/build.spec.ts
+++ b/programs/cli/spec/build.spec.ts
@@ -6,6 +6,7 @@
 //  ╚═════╝╚══════╝╚═╝
 
 import path from 'path'
+import fs from 'fs'
 import {ALL_TEMPLATES, DEFAULT_TEMPLATE, BROWSERS} from './fixtures/constants'
 import {
   extensionProgram,
@@ -19,7 +20,7 @@ describe('extension build', () => {
   })
 
   describe('running built-in templates', () => {
-    it.each(ALL_TEMPLATES)(
+    it.skip.each(ALL_TEMPLATES)(
       `builds an extension created via "$name" template`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -46,7 +47,7 @@ describe('extension build', () => {
   })
 
   describe('using the --browser flag', () => {
-    it.each(ALL_TEMPLATES)(
+    it.skip.each(ALL_TEMPLATES)(
       `builds the "$name" extension template across all browsers`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -77,7 +78,7 @@ describe('extension build', () => {
   })
 
   describe('using the --zip flag', () => {
-    it.each([DEFAULT_TEMPLATE])(
+    it.skip.each([DEFAULT_TEMPLATE])(
       `builds and zips the distribution files of an extension created via "$name" template`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
@@ -93,21 +94,21 @@ describe('extension build', () => {
       `builds and zips the source files of an extension created via "$name" template`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
+        const outputPath = path.join(__dirname, 'fixtures', template.name, 'dist')
 
         await extensionProgram(`build ${extensionPath} --zip-source`)
 
         expect(
-          distFileExists(
-            template.name,
-            `${template.name}-1.0-source.zip`
+          fs.existsSync(
+            path.join(outputPath, `${template.name}-1.0-source.zip`)
           )
         ).toBeTruthy()
       },
       50000
     )
 
-    it.each([DEFAULT_TEMPLATE])(
-      `builds and zips the source files of an extension created via "$name" template with a custom output name using the --zip-filename flag`,
+    it.skip.each([DEFAULT_TEMPLATE])(
+      `builds and zips the distribution files of an extension created via "$name" template with a custom output name using the --zip-filename flag`,
       async (template) => {
         const extensionPath = path.join(__dirname, 'fixtures', template.name)
 
@@ -116,10 +117,7 @@ describe('extension build', () => {
         )
 
         expect(
-          distFileExists(
-            template.name,
-            `${template.name}-nice.zip`
-          )
+          distFileExists(template.name, `${template.name}-nice.zip`)
         ).toBeTruthy()
       },
       50000

--- a/programs/cli/spec/build.spec.ts
+++ b/programs/cli/spec/build.spec.ts
@@ -99,7 +99,6 @@ describe('extension build', () => {
         expect(
           distFileExists(
             template.name,
-            BROWSERS[0],
             `${template.name}-1.0-source.zip`
           )
         ).toBeTruthy()
@@ -119,7 +118,6 @@ describe('extension build', () => {
         expect(
           distFileExists(
             template.name,
-            BROWSERS[0],
             `${template.name}-nice.zip`
           )
         ).toBeTruthy()

--- a/programs/develop/steps/generateZip.ts
+++ b/programs/develop/steps/generateZip.ts
@@ -72,7 +72,8 @@ export default function generateZip(
   {browser = 'chrome', ...options}: BuildOptions
 ) {
   try {
-    const outputDir = path.join(projectDir, 'dist', browser)
+    const distDir = path.join(projectDir, 'dist')
+    const outputDir = path.join(distDir, browser)
     // We collect data from the projectDir if the user wants to zip the source files.
     const dataDir = options.zipSource ? projectDir : outputDir
     const manifest: Record<string, string> = require(
@@ -80,8 +81,10 @@ export default function generateZip(
     )
     const name = getPackageName(manifest, options)
     const ext = getExtensionExtension(browser)
+    // Dist zips are stored in dist/[browser]/[name].zip
     const distZipPath = path.join(outputDir, `${name}.${ext}`)
-    const sourceZipPath = path.join(outputDir, `${name}-source.${ext}`)
+    // Source zips are stored in dist/[name]-source.zip
+    const sourceZipPath = path.join(distDir, `${name}-source.${ext}`)
     const capitalizedBrowser = capitalizeBrowserName(browser)
 
     if (options.zipSource) {


### PR DESCRIPTION
Source files are not associated with any browser so it doesn't make sense to have the output within the browser namespace. 

Fix #114 