### PR TITLE
feat(preact): replace react-refresh with @prefresh/webpack

### DIFF
--- a/programs/develop/package.json
+++ b/programs/develop/package.json
@@ -84,6 +84,7 @@
   "optionalDependencies": {
     "@babel/core": "^7.24.9",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",
+    "@prefresh/webpack": "^4.0.1",
     "@svgr/webpack": "^8.1.0",
     "@vue/compiler-sfc": "^3.4.34",
     "babel-loader": "^9.1.3",

--- a/programs/develop/webpack/plugin-js-frameworks/js-tools/preact.ts
+++ b/programs/develop/webpack/plugin-js-frameworks/js-tools/preact.ts
@@ -48,18 +48,17 @@ export async function maybeUsePreact(
   if (!isUsingPreact(projectPath)) return undefined
 
   try {
-    require.resolve('react-refresh')
+    // Fast-refresh for Preact!
+    // https://github.com/preactjs/prefresh
+    require.resolve('@prefresh/webpack')
   } catch (e) {
-    const reactDependencies = [
-      'react-refresh',
-      '@pmmmwh/react-refresh-webpack-plugin',
-      '@svgr/webpack',
-      'react-refresh-typescript'
+    const preactDependencies = [
+      '@prefresh/webpack'
     ]
     const manifest = require(path.join(projectPath, 'manifest.json'))
     const manifestName = manifest.name || 'Extension.js'
 
-    await installOptionalDependencies(manifestName, 'Preact', reactDependencies)
+    await installOptionalDependencies(manifestName, 'Preact', preactDependencies)
 
     // The compiler will exit after installing the dependencies
     // as it can't read the new dependencies without a restart.
@@ -68,7 +67,7 @@ export async function maybeUsePreact(
   }
 
   const preactPlugins: WebpackPluginInstance[] = [
-    new (require('@pmmmwh/react-refresh-webpack-plugin'))()
+    new (require('@prefresh/webpack'))()
   ]
 
   return {


### PR DESCRIPTION
[prefresh](https://github.com/preactjs/prefresh) is a module hot-reloading tool for Preact. In this PR, I used `prefresh` to provide module hot-reloading for Preact.

It seems that `new-preact` and `content-preact` already have module hot-reloading capabilities.