### PR TITLE
fix(develop): support named ReactRefreshRspackPlugin export

### DIFF
--- a/programs/develop/plugin-js-frameworks/js-tools/react.ts
+++ b/programs/develop/plugin-js-frameworks/js-tools/react.ts
@@ -112,7 +112,12 @@ export async function maybeUseReact(
       projectPath,
       dependencyId: '@rspack/plugin-react-refresh',
       moduleAdapter: (mod: any) =>
-        ((mod && mod.default) || mod) as ReactRefreshPluginCtor
+      (
+        mod?.default ??
+        mod?.ReactRefreshRspackPlugin ??
+        mod?.ReactRefreshPlugin ??
+        mod
+      ) as ReactRefreshPluginCtor
     })
 
   const reactPlugins: RspackPluginInstance[] = [


### PR DESCRIPTION
## Summary

This PR fixes the `ReactRefreshPlugin is not a constructor` error when running:

```bash
pnpm extension dev extensions/extension-js-devtools
```

The issue is caused by `@rspack/plugin-react-refresh` exporting the plugin as a named export (`ReactRefreshRspackPlugin`) instead of a default export. The current implementation only checks `mod.default`, causing the module namespace object to be treated as the plugin constructor.

## Changes

* Updated the React refresh plugin resolver to support both default and named exports:

  * `mod.default`
  * `mod.ReactRefreshRspackPlugin`
  * `mod.ReactRefreshPlugin`
* Preserves compatibility with both export shapes while keeping the existing behavior unchanged when a default export is available.

## Test plan

* [x] Automated tests updated or not needed (existing React tests pass)
* [x] Manual testing completed

  * Reproduced the issue on a clean checkout by following the repository setup instructions.
  * Verified that `pnpm extension dev extensions/extension-js-devtools` no longer throws `TypeError: ReactRefreshPlugin is not a constructor`.
  * Ran `pnpm compile`.
  * Ran `pnpm --filter extension-develop test react` (8 tests passed).
* [x] Docs updated or not needed

## Related links

* Issue: Fixes #474
* Discussion: The issue was reproducible on a clean clone after following the documented setup steps. Inspecting `@rspack/plugin-react-refresh` showed that it exports `ReactRefreshRspackPlugin` as a named export rather than a default export. Because the loader only resolved `mod.default`, it received the module namespace object instead of the plugin constructor, resulting in the `TypeError: ReactRefreshPlugin is not a constructor` error during `pnpm extension dev`. This change adds compatibility for both default and named export shapes while preserving the existing behavior.
